### PR TITLE
make astropy not a runtime dependency

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: 2a6b63d3cc6ee9fa0ef78b15ce61acd4cdbd351599d2d3d891e40015fb9b1e0a
 
 build:
-  number: 1
+  number: 2
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv
   entry_points:
@@ -25,7 +25,6 @@ requirements:
     - setuptools >=42
     - setuptools-scm >=3.4.3
   run:
-    - astropy-base
     - attrs
     - bilby.cython >=0.3.0
     - corner
@@ -44,6 +43,7 @@ requirements:
 test:
   requires:
     - python {{ python_min }}
+    - astropy-base
     - gwpy
     - pip
     - python-lal


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

As part of some testing of non-gw Bilby stuff I noticed that astropy is a strong requirement via conda. I've removed astropy as a runtime dependency to match the behaviour through pypi. Astropy is a runtime dependency of [bilby_pipe](https://github.com/conda-forge/bilby_pipe-feedstock/blob/main/recipe/meta.yaml), so anyone using bilby_pipe won't fail to pick it up.

@GregoryAshton @mj-will do either of you have concerns about dropping this?